### PR TITLE
Fixed bug due to change in MongoFormFieldGenerator's generate() method

### DIFF
--- a/mongodbforms/util.py
+++ b/mongodbforms/util.py
@@ -17,7 +17,7 @@ def get_document_options(document):
 class MongoFormFieldGenerator(MongotoolsGenerator):
     """This class generates Django form-fields for mongoengine-fields."""
     
-    def generate(self, field_name, field, **kwargs):
+    def generate(self, field, **kwargs):
         """Tries to lookup a matching formfield generator (lowercase 
         field-classname) and raises a NotImplementedError of no generator
         can be found.


### PR DESCRIPTION
MongoFormFieldGenerator's generate() method no longer takes field_name as a parameter.
