### PR TITLE
KeyError from getitem during save().

### DIFF
--- a/mongodbforms/documentoptions.py
+++ b/mongodbforms/documentoptions.py
@@ -187,7 +187,10 @@ class DocumentMetaWrapper(object):
             self._meta[name] = value
         else:
             super(DocumentMetaWrapper, self).__setattr__(name, value)
-            
+    
+    def __contains__(self,key):
+        return key in self._meta
+    
     def __getitem__(self, key):
         return self._meta[key]
     


### PR DESCRIPTION
During save(), mongoengine.Document checks for the cascade keyword in the _meta dict which MongoDBForm wraps.

MongoDBForm then throws a KeyError from getitem

Implementing a contains() method for documentoptions.py seems to fix it.
