### PR TITLE
I added a simple __iter__ method in the DocumentMetaWrapper to fix a bug

### DIFF
--- a/mongodbforms/documentoptions.py
+++ b/mongodbforms/documentoptions.py
@@ -190,7 +190,10 @@ class DocumentMetaWrapper(object):
             
     def __getitem__(self, key):
         return self._meta[key]
-    
+
+    def __iter__(self):
+        return self._meta.__iter__()
+
     def get(self, key, default=None):
         try:
             return self.__getitem__(key)


### PR DESCRIPTION
I had the following bug, a bit tricky to debug when saving a DocumentForm:

[...]
File "/Users/ageron/dev/myproject/env/src/mongodbforms/mongodbforms/documents.py", line 424, in save
fail_message, commit, construct=False)
File "/Users/ageron/dev/myproject/env/src/mongodbforms/mongodbforms/documents.py", line 106, in save_instance
instance.save()
File "/Users/ageron/dev/myproject/env/lib/python2.7/site-packages/mongoengine/document.py", line 244, in save
warn_cascade = not cascade and 'cascade' not in self._meta
File "/Users/ageron/dev/myproject/env/src/mongodbforms/mongodbforms/documentoptions.py", line 192, in getitem
return self._meta[key]
KeyError: 0

It turns out that "'cascade' not in self._meta" will make python look for an iter method in self._meta (a DocumentMetaWrapper), and since it wasn't there, python fell back to getitem with key = 0 (it would normally increment the counter until it reaches an IndexError). Then getitem(0) looks for the 0 key in the self._meta (this time it's a mongoengine meta), and since it does not exist, it fails. Wow. I guess it must be a python version thing. Anyway, it probably won't hurt to add this iter method.
