### PR TITLE
reduce is in functools module in Python 3

### DIFF
--- a/mongodbforms/documents.py
+++ b/mongodbforms/documents.py
@@ -1,6 +1,7 @@
 import os
 import itertools
 from collections import Callable
+from functools import reduce
 
 from django.utils.datastructures import SortedDict
 from django.forms.forms import BaseForm, get_declared_fields, NON_FIELD_ERRORS, pretty_name


### PR DESCRIPTION
I also tested that "from functools import reduce" works in Python 2, so there should be no problem.
