### PR TITLE
Fixed LazyDocumentMetaWrapper

### DIFF
--- a/mongodbforms/tests.py
+++ b/mongodbforms/tests.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+from django.conf import settings
+
+settings.configure(
+    DEBUG=True,
+    DATABASES={
+        'default': {
+            'ENGINE': 'django.db.backends.sqlite3',
+        }
+    },
+    ROOT_URLCONF='',
+    INSTALLED_APPS=(
+        'django.contrib.auth',
+        'django.contrib.contenttypes',
+        'django.contrib.sessions',
+        'django.contrib.admin',
+        'mongodbforms',
+    )
+)
+
+
+import mongoengine
+from django.test import SimpleTestCase
+from mongodbforms.documentoptions import LazyDocumentMetaWrapper
+
+
+class TestDocument(mongoengine.Document):
+    meta = {'abstract': True}
+
+    name = mongoengine.StringField()
+
+
+class LazyWrapperTest(SimpleTestCase):
+
+    def test_lazy_getitem(self):
+        meta = LazyDocumentMetaWrapper(TestDocument)
+        self.assertTrue(meta['abstract'])
+
+        meta = LazyDocumentMetaWrapper(TestDocument)
+        self.assertTrue(meta.get('abstract'))
+
+        meta = LazyDocumentMetaWrapper(TestDocument)
+        self.assertTrue('abstract' in meta)
+
+        meta = LazyDocumentMetaWrapper(TestDocument)
+        self.assertEqual(len(meta), 1)
+
+        meta = LazyDocumentMetaWrapper(TestDocument)
+        meta.custom = 'yes'
+        self.assertEqual(meta.custom, 'yes')

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def convert_readme():
     return open('README.txt').read()
 
 setup(name='mongodbforms',
-    version='0.3',
+    version='0.3.1',
     description="An implementation of django forms using mongoengine.",
     author='Jan Schrewe',
     author_email='jan@schafproductions.com',


### PR DESCRIPTION
Hello!

Currently LazyDocumentMetaWrapper is implemented incorrectly, thus in some cases you may get 'Attribute error' when using ```__getitem__``` access method, e.g. ```self._meta['id_field']``` in mongoengine. The problem is LazyDocumentMetaWrapper instance is not initialized when using such methods. Check tests for details.