### PR TITLE
Fix import RemovedInDjango19Warning

### DIFF
--- a/mongodbforms/documents.py
+++ b/mongodbforms/documents.py
@@ -8,7 +8,7 @@ from django.forms.forms import (BaseForm, DeclarativeFieldsMetaclass,
 from django.forms.widgets import media_property
 from django.core.exceptions import FieldError
 from django.core.validators import EMPTY_VALUES
-from django.forms.util import ErrorList
+from django.forms.utils import ErrorList
 from django.forms.formsets import BaseFormSet, formset_factory
 from django.utils.translation import ugettext_lazy as _, ugettext
 from django.utils.text import capfirst, get_valid_filename

--- a/mongodbforms/fieldgenerator.py
+++ b/mongodbforms/fieldgenerator.py
@@ -34,14 +34,14 @@ BLANK_CHOICE_DASH = [("", "---------")]
 
 class MongoFormFieldGenerator(object):
     """This class generates Django form-fields for mongoengine-fields."""
-    
+
     # used for fields that fit in one of the generate functions
     # but don't actually have the name.
     generator_map = {
         'sortedlistfield': 'generate_listfield',
         'longfield': 'generate_intfield',
     }
-    
+
     form_field_map = {
         'stringfield': MongoCharField,
         'stringfield_choices': forms.TypedChoiceField,
@@ -63,12 +63,12 @@ class MongoFormFieldGenerator(object):
         'filefield': forms.FileField,
         'imagefield': forms.ImageField,
     }
-    
+
     # uses the same keys as form_field_map
     widget_override_map = {
         'stringfield_long': forms.Textarea,
     }
-    
+
     def __init__(self, field_overrides={}, widget_overrides={}):
         self.form_field_map.update(field_overrides)
         self.widget_override_map.update(widget_overrides)
@@ -83,14 +83,14 @@ class MongoFormFieldGenerator(object):
         # to handle then a simple field
         if isinstance(field, MongoEmbeddedDocumentField):
             return
-        
+
         attr_name = 'generate_%s' % field.__class__.__name__.lower()
         if hasattr(self, attr_name):
             return getattr(self, attr_name)(field, **kwargs)
 
         for cls in field.__class__.__bases__:
             cls_name = cls.__name__.lower()
-            
+
             attr_name = 'generate_%s' % cls_name
             if hasattr(self, attr_name):
                 return getattr(self, attr_name)(field, **kwargs)
@@ -98,7 +98,7 @@ class MongoFormFieldGenerator(object):
             if cls_name in self.form_field_map:
                 attr = self.generator_map.get(cls_name)
                 return getattr(self, attr)(field, **kwargs)
-                
+
         raise NotImplementedError('%s is not supported by MongoForm' %
                                   field.__class__.__name__)
 
@@ -134,7 +134,7 @@ class MongoFormFieldGenerator(object):
             return field.help_text
         else:
             return ''
-            
+
     def get_field_default(self, field):
         if isinstance(field, (MongoListField, MongoMapField)):
             f = field.field
@@ -148,7 +148,7 @@ class MongoFormFieldGenerator(object):
         else:
             d['initial'] = field.default
         return f.default
-        
+
     def check_widget(self, map_key):
         if map_key in self.widget_override_map:
             return {'widget': self.widget_override_map.get(map_key)}
@@ -181,7 +181,7 @@ class MongoFormFieldGenerator(object):
             })
             if field.regex:
                 defaults['validators'] = [RegexValidator(regex=field.regex)]
-            
+
         form_class = self.form_field_map.get(map_key)
         defaults.update(self.check_widget(map_key))
         defaults.update(kwargs)
@@ -324,7 +324,7 @@ class MongoFormFieldGenerator(object):
         # So we just ignore them
         if isinstance(field.field, MongoEmbeddedDocumentField):
             return
-        
+
         defaults = {
             'label': self.get_field_label(field),
             'help_text': self.get_field_help_text(field),
@@ -351,13 +351,13 @@ class MongoFormFieldGenerator(object):
         defaults.update(self.check_widget(map_key))
         defaults.update(kwargs)
         return form_class(**defaults)
-        
+
     def generate_mapfield(self, field, **kwargs):
         # We can't really handle embedded documents here.
         # So we just ignore them
         if isinstance(field.field, MongoEmbeddedDocumentField):
             return
-            
+
         map_key = 'mapfield'
         form_field = self.generate(field.field)
         defaults = {
@@ -433,10 +433,10 @@ class Html5FormFieldGenerator(MongoDefaultFormFieldGenerator):
         override = super(Html5FormFieldGenerator, self).check_widget(map_key)
         if override != {}:
             return override
-        
+
         chunks = map_key.split('field')
         kind = chunks[0]
-        
+
         if kind == 'email':
             if hasattr(forms, 'EmailInput'):
                 return {'widget': forms.EmailInput}

--- a/mongodbforms/fieldgenerator.py
+++ b/mongodbforms/fieldgenerator.py
@@ -130,7 +130,7 @@ class MongoFormFieldGenerator(object):
         return ''
 
     def get_field_help_text(self, field):
-        if field.help_text:
+        if hasattr(field, 'help_text'):
             return field.help_text
         else:
             return ''

--- a/mongodbforms/fields.py
+++ b/mongodbforms/fields.py
@@ -24,7 +24,7 @@ except ImportError:
         from django.forms.util import smart_unicode
         
 from django.utils.translation import ugettext_lazy as _
-from django.forms.util import ErrorList
+from django.forms.utils import ErrorList
 from django.core.exceptions import ValidationError
 
 try:  # objectid was moved into bson in pymongo 1.9

--- a/mongodbforms/util.py
+++ b/mongodbforms/util.py
@@ -13,7 +13,7 @@ except ImportError:
     # pass on this. So we do define it here for now.
     import sys
     from django.core.exceptions import ImproperlyConfigured
-    from django.utils.importlib import import_module
+    from importlib import import_module
     from django.utils import six
 
     def import_by_path(dotted_path, error_prefix=''):

--- a/mongodbforms/widgets.py
+++ b/mongodbforms/widgets.py
@@ -5,7 +5,7 @@ from django.forms.widgets import (Widget, Media, TextInput,
                                   MultiWidget, HiddenInput)
 from django.utils.safestring import mark_safe
 from django.core.validators import EMPTY_VALUES
-from django.forms.util import flatatt
+from django.forms.utils import flatatt
 
 
 class Html5SplitDateTimeWidget(SplitDateTimeWidget):

--- a/mongodbforms/widgets.py
+++ b/mongodbforms/widgets.py
@@ -25,13 +25,13 @@ class BaseContainerWidget(Widget):
         self.data_widget = data_widget
         self.data_widget.is_localized = self.is_localized
         super(BaseContainerWidget, self).__init__(attrs)
-        
+
     def id_for_label(self, id_):
         # See the comment for RadioSelect.id_for_label()
         if id_:
             id_ += '_0'
         return id_
-        
+
     def format_output(self, rendered_widgets):
         """
         Given a list of rendered widgets (as strings), returns a Unicode string
@@ -51,7 +51,7 @@ class BaseContainerWidget(Widget):
         media = media + self.data_widget.media
         return media
     media = property(_get_media)
-    
+
     def __deepcopy__(self, memo):
         obj = super(BaseContainerWidget, self).__deepcopy__(memo)
         obj.data_widget = copy.deepcopy(self.data_widget)
@@ -64,7 +64,7 @@ class ListWidget(BaseContainerWidget):
             raise TypeError(
                 "Value supplied for %s must be a list or tuple." % name
             )
-                
+
         output = []
         value = [] if value is None else value
         final_attrs = self.build_attrs(attrs)
@@ -103,12 +103,12 @@ class MapWidget(BaseContainerWidget):
     def render(self, name, value, attrs=None):
         if value is not None and not isinstance(value, dict):
             raise TypeError("Value supplied for %s must be a dict." % name)
-                
+
         output = []
         final_attrs = self.build_attrs(attrs)
         id_ = final_attrs.get('id', None)
         fieldset_attr = {}
-        
+
         # in Python 3.X dict.items() returns dynamic *view objects*
         value = list(value.items())
         value.append(('', ''))
@@ -120,13 +120,13 @@ class MapWidget(BaseContainerWidget):
             group = []
             if not self.is_hidden:
                 group.append(mark_safe('<fieldset %s>' % flatatt(fieldset_attr)))
-            
+
             if id_:
                 final_attrs = dict(final_attrs, id='%s_key_%s' % (id_, i))
             group.append(self.key_widget.render(
                 name + '_key_%s' % i, key, final_attrs)
             )
-            
+
             if id_:
                 final_attrs = dict(final_attrs, id='%s_value_%s' % (id_, i))
             group.append(self.data_widget.render(
@@ -134,7 +134,7 @@ class MapWidget(BaseContainerWidget):
             )
             if not self.is_hidden:
                 group.append(mark_safe('</fieldset>'))
-            
+
             output.append(mark_safe(''.join(group)))
         return mark_safe(self.format_output(output))
 
@@ -168,10 +168,10 @@ class MapWidget(BaseContainerWidget):
         obj.key_widget = copy.deepcopy(self.key_widget)
         return obj
 
-        
+
 class HiddenMapWidget(MapWidget):
     is_hidden = True
-    
+
     def __init__(self, attrs=None):
         data_widget = HiddenInput()
         super(MapWidget, self).__init__(data_widget, attrs)


### PR DESCRIPTION
`django.forms.util` now is called `utils` and `django.utils.importlib` was an alias that has now been removed
